### PR TITLE
fixed 6-duplicated-entries-credentials-after-adding-new

### DIFF
--- a/main.py
+++ b/main.py
@@ -88,6 +88,7 @@ class CredentialsList:
         self.root_window.clipboard_append(decrypted)
 
     def load_credentials_to_tree(self):
+        self.tree.delete(*self.tree.get_children())
         with Session(self.db) as session:
             credentials = session.query(Credential).all()
             for credential in credentials:


### PR DESCRIPTION
Fixed #6 by added cleaning tree before loading it to the tab