### PR TITLE
12/ remove sites table from database

### DIFF
--- a/install.py
+++ b/install.py
@@ -6,16 +6,10 @@ from models import UserModel
 def create_database(engine):
     meta = MetaData()
 
-    sites = Table(
-        "sites", meta,
-        Column("id", Integer, primary_key=True),
-        Column("name", String),
-    )
-
     credentials = Table(
         "credentials", meta,
         Column("id", Integer, primary_key=True),
-        Column("site_id", Integer),
+        Column("title", String),
         Column("login", String),
         Column("password", String),
     )

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from crypto import Crypto
 from install import create_database, create_main_password
-from models import CredentialModel, SiteModel, UserModel
+from models import CredentialModel, UserModel
 
 
 class LogIn:
@@ -86,7 +86,6 @@ class AddCredential:
     def on_click_add_password(self, event):
         with Session(self.db) as session:
             site = self.site_textbox.get()
-            site = SiteModel(name=site)
             login = self.login_textbox.get()
             password = self.password_textbox.get()
             password = self.crypto.encrypt(password)
@@ -118,7 +117,6 @@ class CredentialsList:
         selection = self.tree.item(item, "values")
         with Session(self.db) as session:
             credential = session.query(CredentialModel).filter(
-                SiteModel.name == selection[0],
                 CredentialModel.login == selection[1],
                 ).one()
 

--- a/main.py
+++ b/main.py
@@ -64,17 +64,17 @@ class AddCredential:
         self.tabsystem = tabsystem
         self.crypto = Crypto(main_password)
 
-        site_label = ttk.Label(tab, text="Title")
-        site_label.grid(row=0, column=0, padx=5, sticky=tk.E)
-        self.site_textbox = ttk.Entry(tab)
-        self.site_textbox.grid(row=0, column=1, pady=5)
+        title_label = ttk.Label(tab, text="Title:")
+        title_label.grid(row=0, column=0, padx=5, sticky=tk.E)
+        self.title_textbox = ttk.Entry(tab)
+        self.title_textbox.grid(row=0, column=1, pady=5)
 
-        login_label = ttk.Label(tab, text="Login")
+        login_label = ttk.Label(tab, text="Login:")
         login_label.grid(row=1, column=0, padx=5, sticky=tk.E)
         self.login_textbox = ttk.Entry(tab)
         self.login_textbox.grid(row=1, column=1, pady=5)
 
-        password_label = ttk.Label(tab, text="Password")
+        password_label = ttk.Label(tab, text="Password:")
         password_label.grid(row=2, column=0, padx=5, sticky=tk.E)
         self.password_textbox = ttk.Entry(tab, show="*")
         self.password_textbox.grid(row=2, column=1, pady=5)
@@ -85,19 +85,19 @@ class AddCredential:
 
     def on_click_add_password(self, event):
         with Session(self.db) as session:
-            site = self.site_textbox.get()
+            title = self.title_textbox.get()
             login = self.login_textbox.get()
             password = self.password_textbox.get()
             password = self.crypto.encrypt(password)
-            credential = CredentialModel(site=site, login=login, password=password)
-            session.add_all([site, credential])
+            credential = CredentialModel(title=title, login=login, password=password)
+            session.add(credential)
             session.commit()
-            self.clear_textboxes()
-            self.credentials_list.load_credentials_to_tree()
-            self.tabsystem.select(0)
+        self.clear_textboxes()
+        self.credentials_list.load_credentials_to_tree()
+        self.tabsystem.select(0)
 
     def clear_textboxes(self):
-        self.site_textbox.delete(0, tk.END)
+        self.title_textbox.delete(0, tk.END)
         self.login_textbox.delete(0, tk.END)
         self.password_textbox.delete(0, tk.END)
 
@@ -119,7 +119,6 @@ class CredentialsList:
             credential = session.query(CredentialModel).filter(
                 CredentialModel.login == selection[1],
                 ).one()
-
             decrypted = self.crypto.decrypt(credential.password)
 
         self.root_window.clipboard_clear()
@@ -130,7 +129,7 @@ class CredentialsList:
         with Session(self.db) as session:
             credentials = session.query(CredentialModel).all()
             for credential in credentials:
-                self.tree.insert("", "end", values=(credential.site.name, credential.login))
+                self.tree.insert("", "end", values=(credential.title, credential.login))
 
     def configure_tree(self, tab):
         scrollbar = ttk.Scrollbar(tab, orient="vertical", command=self.tree.yview)

--- a/models.py
+++ b/models.py
@@ -1,22 +1,16 @@
-from sqlalchemy import create_engine, Integer, Column, String, ForeignKey
-from sqlalchemy.orm import declarative_base, relationship, backref
+from sqlalchemy import create_engine, Integer, Column, String
+from sqlalchemy.orm import declarative_base
 
 engine = create_engine("sqlite:///database.db", echo=False, future=True)
 Base = declarative_base()
 
 
-class SiteModel(Base):
-    __tablename__ = "sites"
-    id = Column(Integer, primary_key=True)
-    name = Column(String(30))
-
-
 class CredentialModel(Base):
     __tablename__ = "credentials"
-    login = Column(String(30), primary_key=True)
-    password = Column(String(30))
-    site_id = Column(Integer, ForeignKey("sites.id"))
-    site = relationship("SiteModel", backref=backref("credentials", uselist=False))
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    title = Column(String(30))
+    login = Column(String(40))
+    password = Column(String(20))
 
 
 class UserModel(Base):


### PR DESCRIPTION
Delete the `sites` table from the database.
Add `title` column, instead of `site_id` column to the `credentials` table.
This is more universal, because the title of the credential can be not only a website, but also an application, game, etc.